### PR TITLE
Fix search stability by comparing the name if score is the same.

### DIFF
--- a/Packages/jp.suzuryg.face-emo/Editor/Detail/View/ExpressionEditor/ExpressionEditorView.cs
+++ b/Packages/jp.suzuryg.face-emo/Editor/Detail/View/ExpressionEditor/ExpressionEditorView.cs
@@ -774,7 +774,11 @@ namespace Suzuryg.FaceEmo.Detail.View.ExpressionEditor
                 foreach (KeyValuePair<string, List<BlendShape>> keyValuePair in categorized)
                 {
                     keyValuePair.Value.RemoveAll(a => a.MatchName(_search) <= 0);
-                    keyValuePair.Value.Sort((a, b) => b.MatchName(_search).CompareTo(a.MatchName(_search)));
+                    keyValuePair.Value.Sort((a, b) =>
+                    {
+                        var compareTo = b.MatchName(_search).CompareTo(a.MatchName(_search));
+                        return compareTo == 0 ? string.CompareOrdinal(a.Name, b.Name) : compareTo;
+                    });
                 }
             }
 


### PR DESCRIPTION
I've notice that due to some other changes the search is also executed more often, causing the results to jump around due to having the same score while searching. So now it will be sorted by name when the score is the same.

This does not interfere with https://github.com/suzuryg/face-emo/issues/164 but if possible the whole search result should be also cached when fixing that.