### PR TITLE
Added transparency in thumbnail rendering

### DIFF
--- a/Packages/jp.suzuryg.face-emo/Editor/Detail/Drawing/ThumbnailDrawer.cs
+++ b/Packages/jp.suzuryg.face-emo/Editor/Detail/Drawing/ThumbnailDrawer.cs
@@ -1,4 +1,4 @@
-using Suzuryg.FaceEmo.Domain;
+﻿using Suzuryg.FaceEmo.Domain;
 using Suzuryg.FaceEmo.Components.Settings;
 using Suzuryg.FaceEmo.Detail.AV3;
 using Suzuryg.FaceEmo.Detail.View;


### PR DESCRIPTION
This change gets rid of the skybox showing up in thumbnails and makes the background properly transparent. Not 100% sure if this is the best way to do it, but it’s what worked for me.