### PR TITLE
feat: allow controlling animation progress for expression thumbnails

### DIFF
--- a/Packages/jp.suzuryg.face-emo/Editor/Detail/Drawing/ThumbnailDrawer.cs
+++ b/Packages/jp.suzuryg.face-emo/Editor/Detail/Drawing/ThumbnailDrawer.cs
@@ -27,6 +27,7 @@ namespace Suzuryg.FaceEmo.Detail.Drawing
         protected override float CameraPosY => _thumbnailSetting.Main_CameraPosY;
         protected override float CameraAngleX => _thumbnailSetting.Main_CameraAngleV;
         protected override float CameraAngleY => _thumbnailSetting.Main_CameraAngleH;
+        protected override float AnimationProgress => _thumbnailSetting.Main_AnimationProgress;
         public MainThumbnailDrawer(AV3Setting aV3Setting, ThumbnailSetting thumbnailSetting) : base(aV3Setting, thumbnailSetting) { }
     }
 
@@ -40,6 +41,7 @@ namespace Suzuryg.FaceEmo.Detail.Drawing
         protected override float CameraPosY => _thumbnailSetting.Main_CameraPosY;
         protected override float CameraAngleX => _thumbnailSetting.Main_CameraAngleV;
         protected override float CameraAngleY => _thumbnailSetting.Main_CameraAngleH;
+        protected override float AnimationProgress => _thumbnailSetting.Main_AnimationProgress;
         public GestureTableThumbnailDrawer(AV3Setting aV3Setting, ThumbnailSetting thumbnailSetting) : base(aV3Setting, thumbnailSetting) { }
     }
 
@@ -53,6 +55,7 @@ namespace Suzuryg.FaceEmo.Detail.Drawing
         protected override float CameraPosY => _thumbnailSetting.Main_CameraPosY;
         protected override float CameraAngleX => _thumbnailSetting.Main_CameraAngleV;
         protected override float CameraAngleY => _thumbnailSetting.Main_CameraAngleH;
+        protected override float AnimationProgress => _thumbnailSetting.Main_AnimationProgress;
         public ExMenuThumbnailDrawer(AV3Setting aV3Setting, ThumbnailSetting thumbnailSetting) : base(aV3Setting, thumbnailSetting) { }
     }
 
@@ -66,6 +69,7 @@ namespace Suzuryg.FaceEmo.Detail.Drawing
         protected override float CameraPosY => _thumbnailSetting.Main_CameraPosY;
         protected override float CameraAngleX => _thumbnailSetting.Main_CameraAngleV;
         protected override float CameraAngleY => _thumbnailSetting.Main_CameraAngleH;
+        protected override float AnimationProgress => _thumbnailSetting.Main_AnimationProgress;
         public InspectorThumbnailDrawer(AV3Setting aV3Setting, ThumbnailSetting thumbnailSetting) : base(aV3Setting, thumbnailSetting) { }
     }
 
@@ -83,6 +87,7 @@ namespace Suzuryg.FaceEmo.Detail.Drawing
         protected abstract float CameraPosY { get; }
         protected abstract float CameraAngleX { get; }
         protected abstract float CameraAngleY { get; }
+        protected abstract float AnimationProgress { get; }
 
         // Observables
         public IObservable<Unit> OnThumbnailUpdated => _onThumbnailUpdated.AsObservable();
@@ -274,7 +279,7 @@ namespace Suzuryg.FaceEmo.Detail.Drawing
                 var requests = new List<string>(_requests);
                 foreach (var guid in requests)
                 {
-                    _cache[guid] = RenderAnimatedAvatar(guid, clonedAvatar, camera);
+                    _cache[guid] = RenderAnimatedAvatar(guid, clonedAvatar, camera, AnimationProgress);
 
                     // Apply gamma correction if necessary
                     if (this is ExMenuThumbnailDrawer && _cache[guid] != null &&
@@ -327,7 +332,7 @@ namespace Suzuryg.FaceEmo.Detail.Drawing
             SceneManager.MoveGameObjectToScene(light, _previewScene);
         }
 
-        private Texture2D RenderAnimatedAvatar(string clipGUID, GameObject animatorRoot, Camera camera)
+        private Texture2D RenderAnimatedAvatar(string clipGUID, GameObject animatorRoot, Camera camera, float animationProgress = 0f)
         {
             // Get animation clip
             AnimationClip clip;
@@ -356,7 +361,11 @@ namespace Suzuryg.FaceEmo.Detail.Drawing
             {
                 AnimationMode.StartAnimationMode();
                 AnimationMode.BeginSampling();
-                AnimationMode.SampleAnimationClip(animatorRoot, synthesized, synthesized.length);
+                
+                // Set sample time
+                float sampleTime = synthesized.length * animationProgress;
+                AnimationMode.SampleAnimationClip(animatorRoot, synthesized, sampleTime);
+                
                 AnimationMode.EndSampling();
 
                 // When sampling, the object relocates to the origin, so it must be restored to its initial position

--- a/Packages/jp.suzuryg.face-emo/Editor/Detail/Localization/LocalizationTable.cs
+++ b/Packages/jp.suzuryg.face-emo/Editor/Detail/Localization/LocalizationTable.cs
@@ -240,6 +240,7 @@ namespace Suzuryg.FaceEmo.Detail.Localization
         public string InspectorView_Thumbnail_VerticalPosition = "Position (Vertical)";
         public string InspectorView_Thumbnail_HorizontalAngle = "Angle (Horizontal)";
         public string InspectorView_Thumbnail_VerticalAngle = "Angle (Vertical)";
+        public string InspectorView_Thumbnail_AnimationProgress = "Animation Progress";
         public string InspectorView_Thumbnail_Reset = "Reset";
 
         public string InspectorView_Dance = "Dance Gimmick Settings";

--- a/Packages/jp.suzuryg.face-emo/Editor/Detail/Localization/ja_JP.asset
+++ b/Packages/jp.suzuryg.face-emo/Editor/Detail/Localization/ja_JP.asset
@@ -226,6 +226,7 @@ MonoBehaviour:
   InspectorView_Thumbnail_VerticalPosition: "\u4F4D\u7F6E\uFF08\u5782\u76F4\uFF09"
   InspectorView_Thumbnail_HorizontalAngle: "\u89D2\u5EA6\uFF08\u6C34\u5E73\uFF09"
   InspectorView_Thumbnail_VerticalAngle: "\u89D2\u5EA6\uFF08\u5782\u76F4\uFF09"
+  InspectorView_Thumbnail_AnimationProgress: "\u30A2\u30CB\u30E1\u30FC\u30B7\u30E7\u30F3\u9032\u6357"
   InspectorView_Thumbnail_Reset: "\u30EA\u30BB\u30C3\u30C8"
   InspectorView_Dance: "\u30C0\u30F3\u30B9\u30AE\u30DF\u30C3\u30AF\u8A2D\u5B9A"
   InspectorView_Dance_DisableExpressionLayers: "\u8868\u60C5\u30EC\u30A4\u30E4\u30FC\u306E\u307F\u7121\u52B9\u5316"

--- a/Packages/jp.suzuryg.face-emo/Editor/Detail/View/InspectorView.cs
+++ b/Packages/jp.suzuryg.face-emo/Editor/Detail/View/InspectorView.cs
@@ -1054,6 +1054,7 @@ namespace Suzuryg.FaceEmo.Detail.View
                 _localizationTable.InspectorView_Thumbnail_VerticalPosition,
                 _localizationTable.InspectorView_Thumbnail_HorizontalAngle,
                 _localizationTable.InspectorView_Thumbnail_VerticalAngle,
+                _localizationTable.InspectorView_Thumbnail_AnimationProgress,
             };
             var labelWidth = labelTexts
                 .Select(text => GUI.skin.label.CalcSize(new GUIContent(text)).x)
@@ -1084,6 +1085,10 @@ namespace Suzuryg.FaceEmo.Detail.View
             var vAngle = _thumbnailSetting.FindProperty(nameof(ThumbnailSetting.Main_CameraAngleV));
             Field_Slider(_localizationTable.InspectorView_Thumbnail_VerticalAngle, vAngle.floatValue, ThumbnailSetting.MaxCameraAngleV * -1, ThumbnailSetting.MaxCameraAngleV,
                 value => { vAngle.floatValue = value; _thumbnailDrawer.RequestUpdateAll(); }, labelWidth);
+
+            var animProgress = _thumbnailSetting.FindProperty(nameof(ThumbnailSetting.Main_AnimationProgress));
+            Field_Slider(_localizationTable.InspectorView_Thumbnail_AnimationProgress, animProgress.floatValue, ThumbnailSetting.MinAnimationProgress, ThumbnailSetting.MaxAnimationProgress,
+                value => { animProgress.floatValue = value; _thumbnailDrawer.RequestUpdateAll(); }, labelWidth);
 
             EditorGUILayout.Space(10);
 

--- a/Packages/jp.suzuryg.face-emo/Runtime/Components/Settings/ThumbnailSetting.cs
+++ b/Packages/jp.suzuryg.face-emo/Runtime/Components/Settings/ThumbnailSetting.cs
@@ -25,6 +25,10 @@ namespace Suzuryg.FaceEmo.Components.Settings
         [NonSerialized] public static readonly float DefaultCameraAngleV = -5;
         [NonSerialized] public static readonly float MaxCameraAngleV = 30;
 
+        [NonSerialized] public static readonly float DefaultAnimationProgress = 1f;
+        [NonSerialized] public static readonly float MinAnimationProgress = 0f;
+        [NonSerialized] public static readonly float MaxAnimationProgress = 1f;
+
         public int Main_Width = 180;
         public int Main_Height = 150;
         public float Main_FOV = DefaultFOV;
@@ -33,6 +37,7 @@ namespace Suzuryg.FaceEmo.Components.Settings
         public float Main_CameraPosY = DefaultCameraPosY;
         public float Main_CameraAngleH = DefaultCameraAngleH;
         public float Main_CameraAngleV = DefaultCameraAngleV;
+        public float Main_AnimationProgress = DefaultAnimationProgress;
 
         [NonSerialized] public static readonly int Main_MinWidth = 125;
         [NonSerialized] public static readonly int Main_MaxWidth = 300;


### PR DESCRIPTION
As the title suggests, this PR allows controlling the animation progress for expression thumbnail sampling.

Previously, expression thumbnails were fixed to use the last frame of animations. In some preset animations (such as [【キプフェル専用】ぷるぷる♪表情アニメーションセット](https://booth.pm/ja/items/5926402)), the beginning and end of animations feature blinking, which results in all thumbnails showing closed-eye poses. This significantly reduces thumbnail readability and makes it difficult to distinguish between different expressions.

This PR introduces manual control over the animation progress used for thumbnail generation. Users can now set the animation progress to classic values like 0.5 (middle frame) to better showcase expressions. The default animation progress is set to 1.0 (last frame) to maintain backward compatibility with previous versions.

Demo:
**Before:** 
<img width="918" height="1209" alt="image" src="https://github.com/user-attachments/assets/65ac43d6-df1c-48e8-a6c2-78dd81e4c758" />

**Settings UI:**
<img width="656" height="932" alt="image" src="https://github.com/user-attachments/assets/0d88a699-f55d-44e7-a9ff-dbc90cacf209" />

**After:**
<img width="879" height="1201" alt="image" src="https://github.com/user-attachments/assets/2d38d283-ac4e-4777-979c-4c8512de3a7a" />


