### PR TITLE
feat: Add "Show in Emote Select" Feature

### DIFF
--- a/.github/workflows/build-listing.yml
+++ b/.github/workflows/build-listing.yml
@@ -1,6 +1,5 @@
 name: Build Repo Listing
-
-on: 
+on:
   workflow_dispatch:
   workflow_run:
     workflows: [Build Release]
@@ -9,23 +8,20 @@ on:
   release:
      types: [published, created, edited, unpublished, deleted, released]
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
-  
-# Allow one concurrent deployment
+ 
 concurrency:
   group: "pages"
   cancel-in-progress: true
-  
+ 
 env:
   listPublishDirectory: Website
   pathToCi: ci
 
 jobs:
-  
   build-listing:
     name: build-listing
     environment:
@@ -33,35 +29,35 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      
-      - uses: actions/checkout@v3 # check out this repo
-      - uses: actions/checkout@v3 # check out automation repo
+     
+      - uses: actions/checkout@v4 
+      - uses: actions/checkout@v4 
         with:
           repository: vrchat-community/package-list-action
           path: ${{env.pathToCi}}
-          clean: false # otherwise the local repo will no longer be checked out
-          
+          clean: false 
+         
       - name: Restore Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4 
         with:
           path: |
             ${{env.pathToCi}}/.nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
-          
+         
       - name: Build Package Version Listing
         run: ${{env.pathToCi}}/build.cmd BuildRepoListing --root ${{env.pathToCi}} --list-publish-directory $GITHUB_WORKSPACE/${{env.listPublishDirectory}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  
       - name: Setup Pages
-        uses: actions/configure-pages@v2
-        
+        uses: actions/configure-pages@v4 
+       
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3 
         with:
           path: ${{env.listPublishDirectory}}
-          
+         
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4 

--- a/.github/workflows/build-listing.yml
+++ b/.github/workflows/build-listing.yml
@@ -8,11 +8,13 @@ on:
   release:
      types: [published, created, edited, unpublished, deleted, released]
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
  
+# Allow one concurrent deployment
 concurrency:
   group: "pages"
   cancel-in-progress: true
@@ -30,15 +32,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
      
-      - uses: actions/checkout@v4 
-      - uses: actions/checkout@v4 
+      - uses: actions/checkout@v4 # check out this repo
+      - uses: actions/checkout@v4 # check out automation repo
         with:
           repository: vrchat-community/package-list-action
           path: ${{env.pathToCi}}
-          clean: false 
+          clean: false # otherwise the local repo will no longer be checked out
          
       - name: Restore Cache
-        uses: actions/cache@v4 
+        uses: actions/cache@v4
         with:
           path: |
             ${{env.pathToCi}}/.nuke/temp
@@ -51,13 +53,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  
       - name: Setup Pages
-        uses: actions/configure-pages@v4 
+        uses: actions/configure-pages@v4
        
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3 
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ${{env.listPublishDirectory}}
          
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4 
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,40 +1,37 @@
 name: Deploy to GitHub Pages
-
 on:
-  push:
-    branches: [main]
-    paths: [docs/**]
-  workflow_dispatch:
-
+ push:
+   branches: [main]
+   paths: [docs/**]
+ workflow_dispatch:
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: yarn
-          cache-dependency-path: ./docs/package-lock.json
-      - name: Build docs
-        working-directory: docs
-        run: |
-          yarn install --frozen-lockfile
-          yarn build
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./docs/build
-
-  deploy:
-    needs: build
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+ build:
+   runs-on: ubuntu-latest
+   steps:
+     - uses: actions/checkout@v4
+     - uses: actions/setup-node@v4
+       with:
+         node-version: 18
+         cache: yarn
+         cache-dependency-path: ./docs/package-lock.json
+     - name: Build docs
+       working-directory: docs
+       run: |
+         yarn install --frozen-lockfile
+         yarn build
+     - uses: actions/upload-pages-artifact@v3
+       with:
+         path: ./docs/build
+ deploy:
+   needs: build
+   permissions:
+     pages: write
+     id-token: write
+   environment:
+     name: github-pages
+     url: ${{ steps.deployment.outputs.page_url }}
+   runs-on: ubuntu-latest
+   steps:
+     - name: Deploy to GitHub Pages
+       id: deployment
+       uses: actions/deploy-pages@v4

--- a/.github/workflows/pr-auto-approve.yaml
+++ b/.github/workflows/pr-auto-approve.yaml
@@ -1,18 +1,18 @@
 name: Auto Approve
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
+ pull_request:
+   types:
+     - opened
+     - reopened
+     - synchronize
+     - ready_for_review
 jobs:
-  approve:
-    if: |
-      github.event.pull_request.user.login == github.repository_owner
-      && ! github.event.pull_request.draft
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - uses: hmarr/auto-approve-action@v3
+ approve:
+   if: |
+     github.event.pull_request.user.login == github.repository_owner
+     && ! github.event.pull_request.draft
+   runs-on: ubuntu-latest
+   permissions:
+     pull-requests: write
+   steps:
+     - uses: hmarr/auto-approve-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,67 +1,61 @@
 name: Build Release
-
-on: 
-  workflow_dispatch:
-  push:
-    branches: main
-    paths: Packages/jp.suzuryg.face-emo/**
-
+on:
+ workflow_dispatch:
+ push:
+   branches: main
+   paths: Packages/jp.suzuryg.face-emo/**
 env:
-  packageName: "jp.suzuryg.face-emo"
-
+ packageName: "jp.suzuryg.face-emo"
 permissions:
-  contents: write
-
+ contents: write
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    
-      - name: Checkout
-        uses: actions/checkout@v3
-    
-      - name: get version
-        id: version
-        uses: notiz-dev/github-action-json-property@7c8cf5cc36eb85d8d287a8086a39dac59628eb31
-        with: 
-            path: "Packages/${{env.packageName}}/package.json"
-            prop_path: "version"
-            
-      - run: echo ${{steps.version.outputs.prop}} 
-    
-      - name: Set Environment Variables
-        run: |
-          echo "zipFile=${{ env.packageName }}-${{ steps.version.outputs.prop }}".zip >> $GITHUB_ENV
-          echo "unityPackage=${{ env.packageName }}-${{ steps.version.outputs.prop }}.unitypackage" >> $GITHUB_ENV
-        
-      - name: Create Zip
-        uses: thedoctor0/zip-release@09336613be18a8208dfa66bd57efafd9e2685657
-        with:
-          type: "zip"
-          directory: "Packages/${{env.packageName}}/"
-          filename: "../../${{env.zipFile}}" # make the zip file two directories up, since we start two directories in above
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: package-zip
-          path: ${{ env.zipFile }}
+ build:
+   runs-on: ubuntu-latest
+   steps:
+  
+     - name: Checkout
+       uses: actions/checkout@v4
+  
+     - name: get version
+       id: version
+       uses: notiz-dev/github-action-json-property@7c8cf5cc36eb85d8d287a8086a39dac59628eb31
+       with:
+           path: "Packages/${{env.packageName}}/package.json"
+           prop_path: "version"
           
-      - name: Create unitypackage
-        uses: anatawa12/sh-actions/create-unitypackage@cf32b535acd8f4f05a0eb03e0851264122f98f62
-        with:
-          output-path: ${{ env.unityPackage }}
-          package-path: Packages/${{ env.packageName }}
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: unitypackage
-          path: ${{ env.unityPackage }}
+     - run: echo ${{steps.version.outputs.prop}}
+  
+     - name: Set Environment Variables
+       run: |
+         echo "zipFile=${{ env.packageName }}-${{ steps.version.outputs.prop }}".zip >> $GITHUB_ENV
+         echo "unityPackage=${{ env.packageName }}-${{ steps.version.outputs.prop }}.unitypackage" >> $GITHUB_ENV
+      
+     - name: Create Zip
+       uses: thedoctor0/zip-release@09336613be18a8208dfa66bd57efafd9e2685657
+       with:
+         type: "zip"
+         directory: "Packages/${{env.packageName}}/"
+         filename: "../../${{env.zipFile}}" # make the zip file two directories up, since we start two directories in above
+     - uses: actions/upload-artifact@v4
+       with:
+         name: package-zip
+         path: ${{ env.zipFile }}
         
-      - name: Make Release
-        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
-        with:
-          tag_name: ${{ steps.version.outputs.prop }}
-          files: |
-            ${{ env.zipFile }}
-            ${{ env.unityPackage }}
-            Packages/${{ env.packageName }}/package.json
+     - name: Create unitypackage
+       uses: anatawa12/sh-actions/create-unitypackage@cf32b535acd8f4f05a0eb03e0851264122f98f62
+       with:
+         output-path: ${{ env.unityPackage }}
+         package-path: Packages/${{ env.packageName }}
+     - uses: actions/upload-artifact@v4
+       with:
+         name: unitypackage
+         path: ${{ env.unityPackage }}
+      
+     - name: Make Release
+       uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
+       with:
+         tag_name: ${{ steps.version.outputs.prop }}
+         files: |
+           ${{ env.zipFile }}
+           ${{ env.unityPackage }}
+           Packages/${{ env.packageName }}/package.json

--- a/Packages/jp.suzuryg.face-emo/Editor/Detail/AV3/FxGenerator.cs
+++ b/Packages/jp.suzuryg.face-emo/Editor/Detail/AV3/FxGenerator.cs
@@ -789,7 +789,7 @@ namespace Suzuryg.FaceEmo.Detail.AV3
 
                     // Get branches
                     var mode = new ModeExInner(menuItemList.GetMode(id));
-                    var numOfBranches = mode.Branches.Count;
+                    var numOfBranches = mode.Branches.Count(b => b.ShowInEmoteSelect);
                     if (mode.ChangeDefaultFace) { numOfBranches++; }
                     if (numOfBranches <= 0) { continue; }
 
@@ -845,6 +845,10 @@ namespace Suzuryg.FaceEmo.Detail.AV3
                             else
                             {
                                 if (branchIndex >= mode.Branches.Count) { continue; }
+                                
+                                // Skip branches that shouldn't show in emote select menu
+                                if (!mode.Branches[branchIndex].ShowInEmoteSelect) continue;
+                                
                                 guid = mode.Branches[branchIndex].BaseAnimation;
                             }
                             var emoteIndex = GetEmoteIndex(branchIndex, idToModeEx[id], useOverLimitMode);

--- a/Packages/jp.suzuryg.face-emo/Editor/Detail/Localization/LocalizationTable.cs
+++ b/Packages/jp.suzuryg.face-emo/Editor/Detail/Localization/LocalizationTable.cs
@@ -58,8 +58,11 @@ namespace Suzuryg.FaceEmo.Detail.Localization
         public string Common_Tooltip_RightTrigger = "Expressions change according to the pressure level of the right hand trigger. " +
             "Please set an additional expression for when the trigger is pressed. " +
             "Trigger pressing is only valid when the right hand is in Fist.";
+        public string Common_Tooltip_ShowInEmoteSelect = "Include this expression in the manual emote selection menu. " +
+            "When disabled, the expression can only be triggered by gestures.";
         public string Common_Tooltip_LaunchFromHierarchy = "Launch FaceEmo";
-
+        public string Common_ShowInEmoteSelect = "Show in Emote Select";
+        public string Common_Tooltip_ShowInEmoteSelect = "Include this expression in the manual emote selection menu. When disabled, the expression can only be triggered by gestures.";
         public string Launcher_Message_CheckModularAvatar = "Modular Avatar 1.8.0 or later must be installed to use FaceEmo.\n\n" +
             "If ModularAvatar is not installed, or if an older version is installed, please install the latest version.";
         public string Launcher_Message_CheckVrcSdk3Avatars = "VRChat SDK Avatars 3.1.13 or later must be installed to use FaceEmo.\n\n" +

--- a/Packages/jp.suzuryg.face-emo/Editor/Detail/Localization/LocalizationTable.cs
+++ b/Packages/jp.suzuryg.face-emo/Editor/Detail/Localization/LocalizationTable.cs
@@ -62,7 +62,6 @@ namespace Suzuryg.FaceEmo.Detail.Localization
             "When disabled, the expression can only be triggered by gestures.";
         public string Common_Tooltip_LaunchFromHierarchy = "Launch FaceEmo";
         public string Common_ShowInEmoteSelect = "Show in Emote Select";
-        public string Common_Tooltip_ShowInEmoteSelect = "Include this expression in the manual emote selection menu. When disabled, the expression can only be triggered by gestures.";
         public string Launcher_Message_CheckModularAvatar = "Modular Avatar 1.8.0 or later must be installed to use FaceEmo.\n\n" +
             "If ModularAvatar is not installed, or if an older version is installed, please install the latest version.";
         public string Launcher_Message_CheckVrcSdk3Avatars = "VRChat SDK Avatars 3.1.13 or later must be installed to use FaceEmo.\n\n" +

--- a/Packages/jp.suzuryg.face-emo/Editor/Detail/View/BranchListView.cs
+++ b/Packages/jp.suzuryg.face-emo/Editor/Detail/View/BranchListView.cs
@@ -295,9 +295,10 @@ namespace Suzuryg.FaceEmo.Detail.View
             bool? blinkEnabled,
             bool? mouthMorphCancelerEnabled,
             bool? isLeftTriggerUsed,
-            bool? isRightTriggerUsed) args)
+            bool? isRightTriggerUsed,
+            bool? showInEmoteSelect) args)
         {
-            _modifyBranchPropertiesUseCase.Handle("", args.modeId, args.branchIndex, args.eyeTrackingControl, args.mouthTrackingControl, args.blinkEnabled, args.mouthMorphCancelerEnabled, args.isLeftTriggerUsed, args.isRightTriggerUsed);
+            _modifyBranchPropertiesUseCase.Handle("", args.modeId, args.branchIndex, args.eyeTrackingControl, args.mouthTrackingControl, args.blinkEnabled, args.mouthMorphCancelerEnabled, args.isLeftTriggerUsed, args.isRightTriggerUsed, args.showInEmoteSelect);
         }
 
         private void OnAddBranchButtonClicked()

--- a/Packages/jp.suzuryg.face-emo/Editor/Detail/View/Element/BranchListElement.cs
+++ b/Packages/jp.suzuryg.face-emo/Editor/Detail/View/Element/BranchListElement.cs
@@ -55,7 +55,8 @@ namespace Suzuryg.FaceEmo.Detail.View.Element
             bool? blinkEnabled,
             bool? mouthMorphCancelerEnabled,
             bool? isLeftTriggerUsed,
-            bool? isRightTriggerUsed)> OnModifyBranchPropertiesButtonClicked => _onModifyBranchPropertiesButtonClicked.AsObservable();
+            bool? isRightTriggerUsed,
+            bool? showInEmoteSelect)> OnModifyBranchPropertiesButtonClicked => _onModifyBranchPropertiesButtonClicked.AsObservable();
         public IObservable<(string modeId, int from, int to)> OnBranchOrderChanged => _onBranchOrderChanged.AsObservable();
 
         public IObservable<(string modeId, int branchIndex, Condition condition)> OnAddConditionButtonClicked => _onAddConditionButtonClicked.AsObservable();
@@ -76,7 +77,8 @@ namespace Suzuryg.FaceEmo.Detail.View.Element
             bool? blinkEnabled,
             bool? mouthMorphCancelerEnabled,
             bool? isLeftTriggerUsed,
-            bool? isRightTriggerUsed)> _onModifyBranchPropertiesButtonClicked = new Subject<(string modeId, int branchIndex, EyeTrackingControl? eyeTrackingControl, MouthTrackingControl? mouthTrackingControl, bool? blinkEnabled, bool? mouthMorphCancelerEnabled, bool? isLeftTriggerUsed, bool? isRightTriggerUsed)>();
+            bool? isRightTriggerUsed,
+            bool? showInEmoteSelect)> _onModifyBranchPropertiesButtonClicked = new Subject<(string modeId, int branchIndex, EyeTrackingControl? eyeTrackingControl, MouthTrackingControl? mouthTrackingControl, bool? blinkEnabled, bool? mouthMorphCancelerEnabled, bool? isLeftTriggerUsed, bool? isRightTriggerUsed, bool? showInEmoteSelect)>();
         private Subject<(string modeId, int from, int to)> _onBranchOrderChanged = new Subject<(string modeId, int from, int to)>();
 
         private Subject<(string modeId, int branchIndex, Condition condition)> _onAddConditionButtonClicked = new Subject<(string modeId, int branchIndex, Condition condition)>();
@@ -106,6 +108,7 @@ namespace Suzuryg.FaceEmo.Detail.View.Element
         private string _emptyText;
         private string _useLeftTriggerText;
         private string _useRightTriggerText;
+        private string _showInEmoteSelectText;
         private string _notReachableBranchText;
         private string _leftTriggerAnimationText;
         private string _rightTriggerAnimationText;
@@ -321,6 +324,7 @@ namespace Suzuryg.FaceEmo.Detail.View.Element
             _emptyText = localizationTable.BranchListView_EmptyBranch;
             _useLeftTriggerText = localizationTable.BranchListView_UseLeftTrigger;
             _useRightTriggerText = localizationTable.BranchListView_UseRightTrigger;
+            _showInEmoteSelectText = localizationTable.Common_ShowInEmoteSelect;
             _notReachableBranchText = localizationTable.BranchListView_NotReachableBranch;
             _leftTriggerAnimationText = localizationTable.BranchListView_LeftTriggerAnimation;
             _rightTriggerAnimationText = localizationTable.BranchListView_RightTriggerAnimation;
@@ -507,7 +511,7 @@ namespace Suzuryg.FaceEmo.Detail.View.Element
                     new GUIContent(_eyeTrackingText, _localizationTable.Common_Tooltip_EyeTracking));
                 if (eyeTracking != eyeToBool(branch.EyeTrackingControl))
                 {
-                    _onModifyBranchPropertiesButtonClicked.OnNext((SelectedModeId, index, boolToEye(eyeTracking), null, null, null, null, null));
+                    _onModifyBranchPropertiesButtonClicked.OnNext((SelectedModeId, index, boolToEye(eyeTracking), null, null, null, null, null, null));
                 }
 
                 yCurrent += EditorGUIUtility.singleLineHeight + VerticalMargin;
@@ -526,7 +530,7 @@ namespace Suzuryg.FaceEmo.Detail.View.Element
                         new GUIContent(_blinkText, _localizationTable.Common_Tooltip_Blink));
                     if (blink != branch.BlinkEnabled)
                     {
-                        _onModifyBranchPropertiesButtonClicked.OnNext((SelectedModeId, index, null, null, blink, null, null, null));
+                        _onModifyBranchPropertiesButtonClicked.OnNext((SelectedModeId, index, null, null, blink, null, null, null, null));
                     }
                 }
 
@@ -546,7 +550,7 @@ namespace Suzuryg.FaceEmo.Detail.View.Element
                     new GUIContent(_mouthTrackingText, _localizationTable.Common_Tooltip_LipSync));
                 if (mouthTracking != mouthToBool(branch.MouthTrackingControl))
                 {
-                    _onModifyBranchPropertiesButtonClicked.OnNext((SelectedModeId, index, null, boolToMouth(mouthTracking), null, null, null, null));
+                    _onModifyBranchPropertiesButtonClicked.OnNext((SelectedModeId, index, null, boolToMouth(mouthTracking), null, null, null, null, null));
                 }
 
                 yCurrent += EditorGUIUtility.singleLineHeight + VerticalMargin;
@@ -565,7 +569,7 @@ namespace Suzuryg.FaceEmo.Detail.View.Element
                         new GUIContent(_mouthMorphCancelerText, _localizationTable.Common_Tooltip_MouthMorphCanceler));
                     if (mouthMorphCancel != branch.MouthMorphCancelerEnabled)
                     {
-                        _onModifyBranchPropertiesButtonClicked.OnNext((SelectedModeId, index, null, null, null, mouthMorphCancel, null, null));
+                        _onModifyBranchPropertiesButtonClicked.OnNext((SelectedModeId, index, null, null, null, mouthMorphCancel, null, null, null));
                     }
                 }
                 else
@@ -589,7 +593,7 @@ namespace Suzuryg.FaceEmo.Detail.View.Element
                         new GUIContent(_useLeftTriggerText, _localizationTable.Common_Tooltip_LeftTrigger));
                     if (useLeftTrigger != branch.IsLeftTriggerUsed)
                     {
-                        _onModifyBranchPropertiesButtonClicked.OnNext((SelectedModeId, index, null, null, null, null, useLeftTrigger, null));
+                        _onModifyBranchPropertiesButtonClicked.OnNext((SelectedModeId, index, null, null, null, null, useLeftTrigger, null, null));
                     }
                 }
                 else
@@ -613,7 +617,7 @@ namespace Suzuryg.FaceEmo.Detail.View.Element
                         new GUIContent(_useRightTriggerText, _localizationTable.Common_Tooltip_RightTrigger));
                     if (useRightTrigger != branch.IsRightTriggerUsed)
                     {
-                        _onModifyBranchPropertiesButtonClicked.OnNext((SelectedModeId, index, null, null, null, null, null, useRightTrigger));
+                        _onModifyBranchPropertiesButtonClicked.OnNext((SelectedModeId, index, null, null, null, null, null, useRightTrigger, null));
                     }
                 }
                 else
@@ -623,7 +627,20 @@ namespace Suzuryg.FaceEmo.Detail.View.Element
 
                 yCurrent += EditorGUIUtility.singleLineHeight + VerticalMargin;
             }
+            // Show in Emote Select
+            if (!IsSimplified && _aV3Setting.AddConfig_EmoteSelect)
+            {
+                var toggleRect = new Rect(xCurrent, yCurrent, ToggleWidth, EditorGUIUtility.singleLineHeight);
+                var showInEmoteSelect = GUI.Toggle(toggleRect, branch.ShowInEmoteSelect, string.Empty);
+                GUI.Label(new Rect(xCurrent + ToggleWidth, yCurrent, PropertiesWidth - ToggleWidth, EditorGUIUtility.singleLineHeight),
+                    new GUIContent(_showInEmoteSelectText, _localizationTable.Common_Tooltip_ShowInEmoteSelect));
+                if (showInEmoteSelect != branch.ShowInEmoteSelect)
+                {
+                    _onModifyBranchPropertiesButtonClicked.OnNext((SelectedModeId, index, null, null, null, null, null, null, showInEmoteSelect));
+                }
 
+                yCurrent += EditorGUIUtility.singleLineHeight + VerticalMargin;
+            }
             xCurrent += PropertiesWidth + upperHorizontalMargin;
             yCurrent = yBegin;
 

--- a/Packages/jp.suzuryg.face-emo/Runtime/Components/Data/SerializableBranch.cs
+++ b/Packages/jp.suzuryg.face-emo/Runtime/Components/Data/SerializableBranch.cs
@@ -12,7 +12,7 @@ namespace Suzuryg.FaceEmo.Components.Data
         public bool MouthMorphCancelerEnabled;
         public bool IsLeftTriggerUsed;
         public bool IsRightTriggerUsed;
-
+        public bool ShowInEmoteSelect;
         public SerializableAnimation BaseAnimation;
         public SerializableAnimation LeftHandAnimation;
         public SerializableAnimation RightHandAnimation;
@@ -28,6 +28,7 @@ namespace Suzuryg.FaceEmo.Components.Data
             MouthMorphCancelerEnabled = branch.MouthMorphCancelerEnabled;
             IsLeftTriggerUsed = branch.IsLeftTriggerUsed;
             IsRightTriggerUsed = branch.IsRightTriggerUsed;
+            ShowInEmoteSelect = branch.ShowInEmoteSelect;
 
             if (branch.BaseAnimation is Domain.Animation)
             {
@@ -97,7 +98,8 @@ namespace Suzuryg.FaceEmo.Components.Data
                 blinkEnabled: BlinkEnabled,
                 mouthMorphCancelerEnabled: MouthMorphCancelerEnabled,
                 isLeftTriggerUsed: IsLeftTriggerUsed,
-                isRightTriggerUsed: IsRightTriggerUsed);
+                isRightTriggerUsed: IsRightTriggerUsed,
+                showInEmoteSelect: ShowInEmoteSelect);
 
             menu.SetAnimation(BaseAnimation?.Load(), id, index, BranchAnimationType.Base);
             menu.SetAnimation(LeftHandAnimation?.Load(), id, index, BranchAnimationType.Left);

--- a/Packages/jp.suzuryg.face-emo/Runtime/Domain/Branch.cs
+++ b/Packages/jp.suzuryg.face-emo/Runtime/Domain/Branch.cs
@@ -12,7 +12,7 @@ namespace Suzuryg.FaceEmo.Domain
         bool MouthMorphCancelerEnabled { get; }
         bool IsLeftTriggerUsed { get; }
         bool IsRightTriggerUsed { get; }
-
+        bool ShowInEmoteSelect { get; }
         IReadOnlyList<Condition> Conditions { get; }
         bool IsReachable { get; }
         bool CanLeftTriggerUsed { get; }
@@ -32,7 +32,7 @@ namespace Suzuryg.FaceEmo.Domain
         public bool MouthMorphCancelerEnabled { get; set; } = true;
         public bool IsLeftTriggerUsed { get; set; } = false;
         public bool IsRightTriggerUsed { get; set; } = false;
-
+        public bool ShowInEmoteSelect { get; set; } = true;
         public IReadOnlyList<Condition> Conditions => _conditions;
         public bool IsReachable { get; set; } = false;
         public bool CanLeftTriggerUsed { get; set; } = false;

--- a/Packages/jp.suzuryg.face-emo/Runtime/Domain/Menu.cs
+++ b/Packages/jp.suzuryg.face-emo/Runtime/Domain/Menu.cs
@@ -472,9 +472,10 @@ namespace Suzuryg.FaceEmo.Domain
             bool? blinkEnabled = null,
             bool? mouthMorphCancelerEnabled = null,
             bool? isLeftTriggerUsed = null,
-            bool? isRightTriggerUsed = null)
+            bool? isRightTriggerUsed = null,
+            bool? showInEmoteSelect = null)
         {
-            _modes[modeId].ModifyBranchProperties(branchIndex, eyeTrackingControl, mouthTrackingControl, blinkEnabled, mouthMorphCancelerEnabled, isLeftTriggerUsed, isRightTriggerUsed);
+            _modes[modeId].ModifyBranchProperties(branchIndex, eyeTrackingControl, mouthTrackingControl, blinkEnabled, mouthMorphCancelerEnabled, isLeftTriggerUsed, isRightTriggerUsed, showInEmoteSelect);
         }
 
         public bool CanChangeBranchOrder(string modeId, int from) => ContainsBranch(modeId, from);

--- a/Packages/jp.suzuryg.face-emo/Runtime/Domain/Mode.cs
+++ b/Packages/jp.suzuryg.face-emo/Runtime/Domain/Mode.cs
@@ -102,7 +102,8 @@ namespace Suzuryg.FaceEmo.Domain
             bool? blinkEnabled = null,
             bool? mouthMorphCancelerEnabled = null,
             bool? isLeftTriggerUsed = null,
-            bool? isRightTriggerUsed = null)
+            bool? isRightTriggerUsed = null,
+            bool? showInEmoteSelect = null)
         {
             var branch = _branches[branchIndex];
             branch.EyeTrackingControl = eyeTrackingControl ?? branch.EyeTrackingControl;
@@ -111,6 +112,7 @@ namespace Suzuryg.FaceEmo.Domain
             branch.MouthMorphCancelerEnabled = mouthMorphCancelerEnabled ?? branch.MouthMorphCancelerEnabled;
             branch.IsLeftTriggerUsed = isLeftTriggerUsed ?? branch.IsLeftTriggerUsed;
             branch.IsRightTriggerUsed = isRightTriggerUsed ?? branch.IsRightTriggerUsed;
+            branch.ShowInEmoteSelect = showInEmoteSelect ?? branch.ShowInEmoteSelect;
         }
 
         public void ChangeBranchOrder(int from, int to)

--- a/Packages/jp.suzuryg.face-emo/Runtime/UseCase/ModifyMenu/ModifyMode/ModifyBranchPropertiesUseCase.cs
+++ b/Packages/jp.suzuryg.face-emo/Runtime/UseCase/ModifyMenu/ModifyMode/ModifyBranchPropertiesUseCase.cs
@@ -13,7 +13,8 @@ namespace Suzuryg.FaceEmo.UseCase.ModifyMenu.ModifyMode
             bool? blinkEnabled = null,
             bool? mouthMorphCancelerEnabled = null,
             bool? isLeftTriggerUsed = null,
-            bool? isRightTriggerUsed = null);
+            bool? isRightTriggerUsed = null,
+            bool? showInEmoteSelect = null);
     }
 
     public interface IModifyBranchPropertiesPresenter
@@ -63,7 +64,8 @@ namespace Suzuryg.FaceEmo.UseCase.ModifyMenu.ModifyMode
             bool? blinkEnabled = null,
             bool? mouthMorphCancelerEnabled = null,
             bool? isLeftTriggerUsed = null,
-            bool? isRightTriggerUsed = null)
+            bool? isRightTriggerUsed = null,
+            bool? showInEmoteSelect = null)
         {
             try
             {
@@ -87,7 +89,7 @@ namespace Suzuryg.FaceEmo.UseCase.ModifyMenu.ModifyMode
                     return;
                 }
 
-                menu.ModifyBranchProperties(modeId, branchIndex, eyeTrackingControl, mouthTrackingControl, blinkEnabled, mouthMorphCancelerEnabled, isLeftTriggerUsed, isRightTriggerUsed);
+                menu.ModifyBranchProperties(modeId, branchIndex, eyeTrackingControl, mouthTrackingControl, blinkEnabled, mouthMorphCancelerEnabled, isLeftTriggerUsed, isRightTriggerUsed, showInEmoteSelect);
 
                 _menuRepository.Save(menuId, menu, "ModifyBranchProperties");
                 _modifyBranchPropertiesPresenter.Complete(ModifyBranchPropertiesResult.Succeeded, menu);


### PR DESCRIPTION
## Description
This PR adds a new "Show in Emote Select" checkbox feature that allows users to control which expressions appear in the manual emote selection menu while still keeping them available for gesture-based triggering.

## What's Changed

###  New Features
- **Show in Emote Select Toggle**: Added a checkbox for each branch/expression that controls whether it appears in the manual emote selection menu
- **Selective Menu Generation**: Expressions with "Show in Emote Select" disabled are filtered out of the emote selection menu but remain available for gesture activation
- **Default Behavior**: All expressions default to being shown in the emote select menu (backwards compatible)