### PR TITLE
fix: Reuse the pose clip when rendering multiple thumbnails

### DIFF
--- a/Packages/jp.suzuryg.face-emo/Editor/Detail/Drawing/ThumbnailDrawer.cs
+++ b/Packages/jp.suzuryg.face-emo/Editor/Detail/Drawing/ThumbnailDrawer.cs
@@ -282,9 +282,10 @@ namespace Suzuryg.FaceEmo.Detail.Drawing
 
                 // Generate thumbnails
                 var requests = new List<string>(_requests);
+                AnimationClip poseClip = AV3Utility.GetAvatarPoseClip(_aV3Setting?.TargetAvatar as VRCAvatarDescriptor);
                 foreach (var guid in requests)
                 {
-                    _cache[guid] = RenderAnimatedAvatar(guid, clonedAvatar, camera, AnimationProgress);
+                    _cache[guid] = RenderAnimatedAvatar(guid, clonedAvatar, camera, poseClip, AnimationProgress);
 
                     // Apply gamma correction if necessary
                     if (this is ExMenuThumbnailDrawer && _cache[guid] != null &&
@@ -338,7 +339,7 @@ namespace Suzuryg.FaceEmo.Detail.Drawing
             SceneManager.MoveGameObjectToScene(light, _previewScene);
         }
 
-        private Texture2D RenderAnimatedAvatar(string clipGUID, GameObject animatorRoot, Camera camera, float animationProgress = 0f)
+        private Texture2D RenderAnimatedAvatar(string clipGUID, GameObject animatorRoot, Camera camera, AnimationClip poseClip, float animationProgress = 0f)
         {
             // Get animation clip
             AnimationClip clip;
@@ -358,7 +359,7 @@ namespace Suzuryg.FaceEmo.Detail.Drawing
             }
 
             // Synthesize avatar pose
-            var synthesized = AV3Utility.SynthesizeAvatarPose(clip, _aV3Setting?.TargetAvatar as VRCAvatarDescriptor);
+            var synthesized = AV3Utility.SynthesizeClip(clip, poseClip);
 
             // Sample animation clip and render
             var positionCache = animatorRoot.transform.position;


### PR DESCRIPTION
Thanks for all the performance improvements and better code structure!  
But I noticed that opening FaceEmo still takes quite a long time in my main project, this seems to be caused by the Destory (it takes over 400ms in my project) method and after a look at current new code seems like every preview creates new copy to create the pose animation using `GetAvatarPoseClip`
I've decided to edit the `UpdateCoroutine` + `RenderAnimatedAvatar` path to instead generate the pose once, so its still recreated when you re-open the menu to avoid any issues, but its only created once when trying to render the 50+ previews of all gestures.  

With this opening of the main menu is really quick! 