### PR TITLE
fix: Avoid invalidating the cache if smaller size is requested to prevent issues with multiple windows open

### DIFF
--- a/Packages/jp.suzuryg.face-emo/Editor/Detail/Drawing/ThumbnailDrawer.cs
+++ b/Packages/jp.suzuryg.face-emo/Editor/Detail/Drawing/ThumbnailDrawer.cs
@@ -143,6 +143,13 @@ namespace Suzuryg.FaceEmo.Detail.Drawing
             _disposables?.Dispose();
         }
 
+        public Texture2D GetCachedThumbnailOrNull(Domain.Animation animation)
+        {
+            var guid = GetGUID(animation);
+
+            return _cache.GetValueOrDefault(guid, null);
+        }
+
         public Texture2D GetThumbnail(Domain.Animation animation)
         {
             var guid = GetGUID(animation);

--- a/Packages/jp.suzuryg.face-emo/Editor/Detail/View/InspectorView.cs
+++ b/Packages/jp.suzuryg.face-emo/Editor/Detail/View/InspectorView.cs
@@ -1032,15 +1032,23 @@ namespace Suzuryg.FaceEmo.Detail.View
             Rect textureRect = GUILayoutUtility.GetRect(textureWidth, textureHeight, GUILayout.ExpandWidth(true), GUILayout.ExpandHeight(false));
             var width = _thumbnailSetting.FindProperty(nameof(ThumbnailSetting.Inspector_Width));
             var height = _thumbnailSetting.FindProperty(nameof(ThumbnailSetting.Inspector_Height));
+
+            var thumbnailAnimation = new Domain.Animation(string.Empty);
+            // TODO: this method can be executed from different instances of the inspectors of different sizes
             if (width.intValue != textureWidth ||
                 height.intValue != textureHeight)
             {
                 width.intValue = textureWidth;
                 height.intValue = textureHeight;
-                _thumbnailDrawer.RequestUpdateAll();
+                
+                var cachedThumbnail = _thumbnailDrawer.GetCachedThumbnailOrNull(thumbnailAnimation);
+                if (cachedThumbnail != null && (cachedThumbnail.width < width.intValue || cachedThumbnail.height < height.intValue))
+                {
+                    _thumbnailDrawer.RequestUpdateAll();
+                }
             }
             _thumbnailDrawer.Update();
-            var texture = _thumbnailDrawer.GetThumbnail(new Domain.Animation(string.Empty));
+            var texture = _thumbnailDrawer.GetThumbnail(thumbnailAnimation);
             GUI.DrawTexture(textureRect, texture);
 
             EditorGUILayout.Space(10);


### PR DESCRIPTION
This one is a bit more complex and the fix is more of temporary patch as I'm not sure how to fix it fully.  
There is quite a bit of code that seems to be written with assumption that only one instance of window can exist at a time, but this is not true and I experienced a really strong lag when I've opened "Optional Settings" from FaceEmo window while having the Inspector already open on the FaceEmo component.  
This caused both of the window to try to render the thumbnail settings, and both of them keep noticing that the size of the window changed and request new thumbnail...  
My fix is quite simple to just ignore requests like that if the size is smaller, as its not an issue to render a higher resolution image in this case. But probably something more should be done to avoid this issue, but that would require more changes while this fix is good enough to prevent the lag.  