### PR TITLE
fix: Set wrap mode to Clamp for generated expression icons

### DIFF
--- a/Packages/jp.suzuryg.face-emo/Editor/Detail/AV3/FxGenerator.cs
+++ b/Packages/jp.suzuryg.face-emo/Editor/Detail/AV3/FxGenerator.cs
@@ -781,6 +781,7 @@ namespace Suzuryg.FaceEmo.Detail.AV3
             var icon = _exMenuThumbnailDrawer.GetThumbnail(animation);
             if (!AssetDatabase.IsMainAsset(icon) && !AssetDatabase.IsSubAsset(icon)) // Do not save icons that have already been generated and error icons
             {
+                icon.wrapMode = TextureWrapMode.Clamp;
                 AssetDatabase.AddObjectToAsset(icon, container);
                 AssetDatabase.SaveAssets();
                 AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(container));


### PR DESCRIPTION
The `Warp Mode` for generated expression icons in the current version is set to `Repeat`, this results in tiny extra pixels below the icons in the menu.

Change it to Clamp to fix it.